### PR TITLE
Fixed build webassembly

### DIFF
--- a/sardine/Cargo.toml
+++ b/sardine/Cargo.toml
@@ -23,7 +23,7 @@ rand = "0.5.0"
 hmac = "0.6"
 sha2 = "0.7"
 chacha = "0.1.0"
-wasm-bindgen = { version = "=0.2.8", default_features = false, features = ["std"], optional = true}
+wasm-bindgen = { version = "=0.2.15", default_features = false, features = ["std"], optional = true}
 
 num-bigint = {version = "0.1", default_features = false}
 num-traits = {version = "0.1", default_features = false}

--- a/sardine/src/lib.rs
+++ b/sardine/src/lib.rs
@@ -1,4 +1,5 @@
-#![cfg_attr(feature = "wasm", feature(proc_macro, wasm_custom_section, wasm_import_module))]
+#![feature(use_extern_macros)]
+#![cfg_attr(feature = "wasm", feature(wasm_custom_section, wasm_import_module))]
 extern crate byteorder;
 extern crate hmac;
 extern crate num_bigint;
@@ -40,6 +41,7 @@ cfg_if! {
 #[cfg(test)]
 mod tests;
 
+#[allow(dead_code)]
 #[cfg(feature = "wasm")]
 fn main() {}
 


### PR DESCRIPTION
With those changes, I can run the build script wasm_build.sh

To build the wasm version, you need to be configured correctly.  
- Install target wasm32-unknown-unknown for nightly toolchain 
    CMD to run : rustup target add wasm32-unknown-unknown --toolchain nightly

- Install wasm-bindgen tool : 
    CMD to run : cargo +nightly install wasm-bindgen-cli

The script wasm_build works and I got the output sardine_bg.wasm.  I didn't try if the wasm file works though.