### PR TITLE
Uses AES-NI on x86 and constant time AES on other platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,3 @@ members = [
     "sardine",
     "hyper"
 ]
-
-[patch.crates-io]
-block-padding = { git = "https://github.com/zer0x64/utils", rev = "1fa554a4b38bcbb99b6b0d29d3fb1ad2ecc821d"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ members = [
     "sardine",
     "hyper"
 ]
+
+[patch.crates-io]
+block-padding = { git = "https://github.com/zer0x64/utils", rev = "1fa554a4b38bcbb99b6b0d29d3fb1ad2ecc821d"}

--- a/sardine/Cargo.toml
+++ b/sardine/Cargo.toml
@@ -29,7 +29,8 @@ wasm-bindgen = { version = "0.2", default_features = false, features = ["std"], 
 num-bigint = {version = "0.1", default_features = false}
 num-traits = {version = "0.1", default_features = false}
 num-integer = {version = "0.1", default_features = false}
-aes_frast = {version = "0.1.2", optional = true}
+aes256 = {package = "aes", version = "0.3.2", optional = true}
+block-modes = {version = "0.3.3", optional = true}
 
 byteorder = "1.2"
 
@@ -38,7 +39,7 @@ libc = "0.2.40"
 [features]
 default = []
 wasm = ["wasm-bindgen", "rand/wasm-bindgen"]
-aes = ["aes_frast"]
+aes = ["aes256", "block-modes"]
 fips = ["aes"]
 
 # Workaround for building webassembly withouth breaking CI. For webassembly, build with --bin. Work currently in progress to allow target based crate-type.

--- a/sardine/src/lib.rs
+++ b/sardine/src/lib.rs
@@ -4,9 +4,6 @@ extern crate num_bigint;
 extern crate rand;
 extern crate sha2;
 
-#[cfg(feature = "aes")]
-extern crate aes_frast;
-
 extern crate chacha;
 
 #[macro_use]
@@ -33,6 +30,14 @@ cfg_if! {
     }
     else {
         pub mod ffi;
+    }
+}
+
+cfg_if! {
+    if #[cfg(feature = "aes")] {
+        extern crate aes256 as aes;
+        extern crate block_modes;
+
     }
 }
 

--- a/sardine/src/srd_errors.rs
+++ b/sardine/src/srd_errors.rs
@@ -119,3 +119,20 @@ impl From<rand::Error> for SrdError {
         SrdError::Rng
     }
 }
+
+cfg_if! {
+    if #[cfg(feature = "aes")] {
+        use block_modes::{InvalidKeyIvLength, BlockModeError};
+        impl From<InvalidKeyIvLength> for SrdError {
+            fn from(_error: InvalidKeyIvLength) -> SrdError{
+                SrdError::Crypto
+            }
+        }
+
+        impl From<BlockModeError> for SrdError {
+            fn from(_error: BlockModeError) -> SrdError{
+                SrdError::Crypto
+            }
+        }
+    }
+}

--- a/sardine/src/tests/srd_tests.rs
+++ b/sardine/src/tests/srd_tests.rs
@@ -116,6 +116,7 @@ fn good_login_logon_blob() {
     client_ciphers.push(Cipher::XChaCha20);
 
     let mut server_ciphers = Vec::new();
+    //server_ciphers.push(Cipher::AES256);
     server_ciphers.push(Cipher::ChaCha20);
     server_ciphers.push(Cipher::XChaCha20);
 


### PR DESCRIPTION
The current implementation uses `aes-frast`, which is not really supported anymore and doesn't uses AES-NI, which is required for FIPS compliance. 

This pull request aims to change the crate to `aes`, which is still active, uses AES-NI when possible and is reviewed against side-channel attacks.

Note that I currently have a PR open on `block-padding` to support encryption without padding and currently the library is overriden using a `patch` manifest key. We can wait until the change makes it into crates.io before merging, hence the WIP tag.